### PR TITLE
Enconding improvements

### DIFF
--- a/source/Parser.php
+++ b/source/Parser.php
@@ -131,10 +131,10 @@ class Parser
     {
         $code = $this->getCodeWithMacros($code);
         $code = $this->getCodeWithCompilers($code);
-        $code = base64_encode($code);
+        $code = base64_encode(gzencode($code));
 
         return defer("
-            \$code = base64_decode('{$code}');
+            \$code = gzdecode(base64_decode('{$code}'));
             \$engine = new \Yay\Engine;
 
             gc_disable();
@@ -151,7 +151,7 @@ class Parser
             $this->getCompilers(),
             $this->getDiscoveredCompilers()
         );
-        
+
         foreach ($compilers as $compiler) {
             if (is_callable($compiler)) {
                 $code = $compiler($code);
@@ -167,7 +167,7 @@ class Parser
             $this->getMacros(),
             $this->getDiscoveredMacros()
         );
-        
+
         foreach ($macros as $macro) {
             if (file_exists($macro)) {
                 $code = str_replace(

--- a/source/functions.php
+++ b/source/functions.php
@@ -31,7 +31,7 @@ function defer($code)
 {
     $hidden = realpath(__DIR__ . "/../hidden/vendor/autoload.php");
     $visible = find("autoload.php");
-    
+
     if (!$visible) {
         // the plugin is being used/tested directly
         $visible = __DIR__ . "/../vendor/autoload.php";
@@ -45,14 +45,14 @@ function defer($code)
             {$code};
         };
 
-        print base64_encode(serialize(\$function()));
+        print base64_encode(gzencode(\$function()));
     ";
 
     $result = exec(
         "php -r 'eval(base64_decode(\"" . base64_encode($defer) . "\"));'"
     );
-    
-    return unserialize(base64_decode($result));
+
+    return gzdecode(base64_decode($result));
 }
 
 function instance()


### PR DESCRIPTION
Hi,

Testing the plugin on several libraries, I found that the `serialize` encoding is not working for all cases.

This is one the file that was generating the issue: https://github.com/illuminate/support/blob/v5.6.39/helpers.php

In this PR, I've improved the encoding with gzencode/gzdecode in the `parse` method. To be consistent, I've also replaced it in the `defer` method.