### PR TITLE
Switch to using PHP_BINARY

### DIFF
--- a/source/functions.php
+++ b/source/functions.php
@@ -52,7 +52,7 @@ if (!function_exists("\\Pre\\Plugin\\defer")) {
         ";
 
         $result = exec(
-            "php -r 'eval(base64_decode(\"" . base64_encode($defer) . "\"));'"
+            escapeshellcmd(PHP_BINARY) . " -r 'eval(base64_decode(\"" . base64_encode($defer) . "\"));'"
         );
 
         return gzdecode(base64_decode($result));


### PR DESCRIPTION
If you have multiple php installs, the current implementation does not work. This replaces the global `php` lookup, with the [`PHP_BINARY`](https://www.php.net/manual/en/reserved.constants.php) constant (added in 5.4). 