### PR TITLE
Add some error handling, to make debuging a touch easier

### DIFF
--- a/source/functions.php
+++ b/source/functions.php
@@ -52,10 +52,18 @@ if (!function_exists("\\Pre\\Plugin\\defer")) {
         ";
 
         $result = exec(
-            "php -r 'eval(base64_decode(\"" . base64_encode($defer) . "\"));'"
+            "php -r 'eval(base64_decode(\"" . base64_encode($defer) . "\"));'",
+            $output
         );
 
-        return gzdecode(base64_decode($result));
+
+        $return = @gzdecode(base64_decode($result));
+
+        if ($return === false) {
+            throw new \RuntimeException("defer failed due to " . implode("\n", $output));
+        }
+
+        return $return;
     }
 }
 


### PR DESCRIPTION
Currently, if the defer() code fails, you just get warning about gzdecode failing. This PR will add some error handling and turn it into an exception with some included debug information.