### PR TITLE
Switch autoloader to use process()

### DIFF
--- a/source/Parser.php
+++ b/source/Parser.php
@@ -87,12 +87,12 @@ class Parser
         return [];
     }
 
-    public function process($from)
+    public function process($from, $to = '', $format = true, $comment = true)
     {
-        $to = preg_replace("/\.[a-zA-Z]+$/", ".php", $from);
+        $to = !empty($to) ? $to : preg_replace("/\.[a-zA-Z]+$/", ".php", $from);
 
         if (!$this->isProcessed($from, $to)) {
-            $this->compile($from, $to);
+            $this->compile($from, $to, $format, $comment);
         }
 
         return require $to;

--- a/source/autoload.php
+++ b/source/autoload.php
@@ -32,9 +32,7 @@ spl_autoload_register(function ($class) {
                 continue;
             }
 
-            compile($pre, $php, $format = true, $comment = true);
-
-            require_once $php;
+            process($pre, $php, $format = true, $comment = true);
         }
     }
 }, false, true);

--- a/source/functions.php
+++ b/source/functions.php
@@ -72,9 +72,9 @@ if (!function_exists("\\Pre\\Plugin\\instance")) {
 }
 
 if (!function_exists("\\Pre\\Plugin\\process")) {
-    function process($from) {
+    function process($from, $to = '', $format = true, $comment = true) {
         $instance = instance();
-        return $instance->process($from);
+        return $instance->process($from, $to, $format, $comment);
     }
 }
 


### PR DESCRIPTION
Currently, the autoloader compiles files on every request as it calls `compile()`. This PR switches to using `process()` which only compiles if the file was changed.

Definitely could use some guidance here...